### PR TITLE
added correct receipt status for old txs (pre-Byzantine EIP-658 block…

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -416,3 +416,8 @@ func (b *EthAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
 	return b.eth.stateAtTransaction(ctx, block, txIndex, reexec)
 }
+
+func (b *EthAPIBackend) StateAtTransactionX(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, error) {
+	msg, blckCtx, statedb, _, err := b.eth.stateAtTransaction(ctx, block, txIndex, reexec)
+	return msg, blckCtx, statedb, err
+}

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -101,6 +101,16 @@ func (ec *Client) BlockNumber(ctx context.Context) (uint64, error) {
 	return uint64(result), err
 }
 
+// BlockReceipts returns the receipts of a given block number or hash
+func (ec *Client) BlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error) {
+	var r []*types.Receipt
+	err := ec.c.CallContext(ctx, &r, "eth_getBlockReceipts", blockNrOrHash)
+	if err == nil && r == nil {
+		return nil, ethereum.NotFound
+	}
+	return r, err
+}
+
 type rpcBlock struct {
 	Hash         common.Hash         `json:"hash"`
 	Transactions []rpcTransaction    `json:"transactions"`

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -97,6 +97,8 @@ type Backend interface {
 	SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Subscription
 	BloomStatus() (uint64, uint64)
 	ServiceFilter(ctx context.Context, session *bloombits.MatcherSession)
+	// alexqrid
+	StateAtTransactionX(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, error)
 }
 
 func GetAPIs(apiBackend Backend) []rpc.API {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -623,6 +623,11 @@ web3._extend({
 			params: 1,
 		}),
 		new web3._extend.Method({
+			name: 'getBlockReceipts',
+			call: 'eth_getBlockReceipts',
+			params: 1,
+		}),
+		new web3._extend.Method({
 			name: 'call',
 			call: 'eth_call',
 			params: 4,

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -337,3 +337,7 @@ func (b *LesApiBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 func (b *LesApiBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
 	return b.eth.stateAtTransaction(ctx, block, txIndex, reexec)
 }
+func (b *LesApiBackend) StateAtTransactionX(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, error) {
+	msg, blckCtx, statedb, _, err := b.eth.stateAtTransaction(ctx, block, txIndex, reexec)
+	return msg, blckCtx, statedb, err
+}


### PR DESCRIPTION
This PR adds support for:
* correct transaction status for pre-Byzantine blocks, that is returned in receipts.
* adds `eth_getBlockReceipts` api method